### PR TITLE
Fix chart rendering and improve dark theme readability

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,7 +180,7 @@ async def worker_loop():
                     )
                 )
                 db.session.commit()
-                print(f"[{datetime.utcnow()}] {u.username}: {st_text}")
+                print(f"[{datetime.now(dt_timezone.utc)}] {u.username}: {st_text}")
         await asyncio.sleep(interval)
 
 # run coroutine safely on tele_loop

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -68,9 +68,12 @@
       data: item.data,
       borderColor: palette[index % palette.length],
       backgroundColor: palette[index % palette.length] + '33',
+      parsing: { xAxisKey: 'x', yAxisKey: 'y' },
       stepped: true,
       fill: true,
-      pointRadius: 2
+      pointRadius: 2,
+      tension: 0,
+      borderWidth: 2
     }));
     new Chart(ctx, {
       type: 'line',
@@ -86,8 +89,8 @@
             grid: { color: 'rgba(255,255,255,0.12)' }
           },
           y: {
-            suggestedMin: 0,
-            suggestedMax: 1,
+            min: 0,
+            max: 1,
             ticks: {
               callback: value => value === 1 ? 'Онлайн' : 'Оффлайн',
               stepSize: 1,

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,6 +71,26 @@
       .btn {
         border-radius: 0.75rem;
       }
+      .form-control,
+      .form-select {
+        background: rgba(15, 32, 39, 0.65);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        color: #f8f9fa;
+      }
+      .form-control:focus,
+      .form-select:focus {
+        background: rgba(15, 32, 39, 0.85);
+        border-color: rgba(76, 175, 80, 0.5);
+        box-shadow: none;
+        color: #fff;
+      }
+      .form-control::placeholder {
+        color: rgba(248, 249, 250, 0.6);
+      }
+      .form-select option {
+        background-color: #0f2027;
+        color: #f8f9fa;
+      }
       .list-group-item {
         background: rgba(255, 255, 255, 0.04);
         border-color: rgba(255, 255, 255, 0.08);

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -76,10 +76,12 @@
           data: chartSource.data,
           borderColor: palette.line,
           backgroundColor: palette.background,
+          parsing: { xAxisKey: 'x', yAxisKey: 'y' },
           fill: true,
           stepped: true,
-          tension: 0.3,
-          pointRadius: 3
+          tension: 0,
+          pointRadius: 3,
+          borderWidth: 2
         }]
       },
       options: {
@@ -93,8 +95,8 @@
             grid: { color: 'rgba(255,255,255,0.1)' }
           },
           y: {
-            suggestedMin: 0,
-            suggestedMax: 1,
+            min: 0,
+            max: 1,
             ticks: {
               callback: value => value === 1 ? 'Онлайн' : 'Оффлайн',
               stepSize: 1,

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -60,12 +60,12 @@
       <div class="card-body">
         <h5 class="card-title mb-3"><i class="bi bi-telegram me-2"></i>Авторизация Telegram</h5>
         {% if stage == 'authorized' %}
-          <div class="alert alert-success text-dark">Статус: Авторизован ✅</div>
+          <div class="alert alert-success">Статус: Авторизован ✅</div>
           <form method="post" action="{{ url_for('http_logout') }}">
             <button class="btn btn-outline-danger w-100" type="submit"><i class="bi bi-box-arrow-right"></i> Разлогиниться</button>
           </form>
         {% elif stage == 'code' %}
-          <div class="alert alert-warning text-dark">Статус: Ожидается код из Telegram</div>
+          <div class="alert alert-warning">Статус: Ожидается код из Telegram</div>
           <form method="post" action="{{ url_for('http_send_code') }}" class="d-grid gap-2 mb-3">
             <button class="btn btn-outline-light" type="submit"><i class="bi bi-send"></i> Отправить код ещё раз</button>
           </form>


### PR DESCRIPTION
## Summary
- eliminate the deprecated datetime.utcnow() usage in the worker logging so timestamps remain UTC-aware
- adjust the log and comparison charts to use explicit 0/1 ranges and disable bezier tension to stop the curve from diving below zero
- refresh the dark theme form and alert styles so text remains legible on dark backgrounds

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cce76ea9548322b90034ae33816b75