### PR TITLE
Fix chart sizing and unify text colors

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -27,7 +27,9 @@
   <div class="card bg-dark bg-opacity-25 border-0 shadow-sm mb-4">
     <div class="card-body">
       <h5 class="card-title mb-3"><i class="bi bi-activity me-2"></i>Сводная активность</h5>
-      <canvas id="compareChart" height="160"></canvas>
+      <div class="chart-container">
+        <canvas id="compareChart"></canvas>
+      </div>
     </div>
   </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,16 @@
       a:hover {
         color: inherit;
       }
+      .card,
+      .card-body,
+      .card-title,
+      .card-text,
+      .form-label,
+      .form-text,
+      label,
+      .table {
+        color: #f8f9fa;
+      }
       .table-dark-glass {
         --bs-table-bg: rgba(15, 32, 39, 0.75);
         --bs-table-striped-bg: rgba(255, 255, 255, 0.05);
@@ -95,6 +105,15 @@
         background: rgba(255, 255, 255, 0.04);
         border-color: rgba(255, 255, 255, 0.08);
         color: #f8f9fa;
+      }
+      .chart-container {
+        position: relative;
+        width: 100%;
+        max-width: 100%;
+        height: 360px;
+      }
+      .chart-container.chart-sm {
+        height: 240px;
       }
     </style>
     {% block extra_head %}{% endblock %}

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -13,7 +13,9 @@
 <div class="card bg-dark bg-opacity-25 border-0 shadow-sm mb-4">
   <div class="card-body">
     <h5 class="card-title mb-3"><i class="bi bi-graph-up-arrow me-2"></i>Онлайн-активность</h5>
-    <canvas id="statusChart" height="140"></canvas>
+    <div class="chart-container chart-sm">
+      <canvas id="statusChart"></canvas>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- wrap activity charts into fixed-height containers to keep canvas height stable
- add shared chart container styles and ensure card and form text is light

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cce8ec7c84832296457d992a40badd