### PR TITLE
Ускорить отправку кода и обновить страницу настроек

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,20 +1,142 @@
 {% extends "base.html" %}
 {% block title %}Настройки{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .settings-hero {
+      background: linear-gradient(135deg, rgba(76, 175, 80, 0.18), rgba(33, 150, 243, 0.18));
+      border-radius: 1.25rem;
+      padding: 1.75rem;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    .stage-flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 1rem;
+      margin-bottom: 0;
+    }
+    .stage-flow li {
+      list-style: none;
+      padding: 1rem;
+      border-radius: 0.9rem;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+    .stage-flow li.active {
+      background: rgba(76, 175, 80, 0.25);
+      border-color: rgba(76, 175, 80, 0.45);
+      box-shadow: 0 0.75rem 2rem rgba(76, 175, 80, 0.2);
+    }
+    .stage-flow li.current {
+      background: rgba(33, 150, 243, 0.25);
+      border-color: rgba(33, 150, 243, 0.45);
+      box-shadow: 0 0.75rem 2rem rgba(33, 150, 243, 0.18);
+    }
+    .stage-flow li.waiting {
+      background: rgba(255, 193, 7, 0.22);
+      border-color: rgba(255, 193, 7, 0.45);
+    }
+    .stage-flow li .stage-index {
+      width: 2.1rem;
+      height: 2.1rem;
+      border-radius: 50%;
+      background: rgba(15, 32, 39, 0.75);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      color: #fff;
+    }
+    .settings-card {
+      background: rgba(15, 32, 39, 0.7);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 1.2rem;
+    }
+    .settings-card .card-body {
+      padding: 1.75rem;
+    }
+    @media (max-width: 991.98px) {
+      .stage-flow {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
-<h1 class="h4 fw-semibold mb-4">Настройки системы</h1>
+{% set stage_badges = {
+  'authorized': ('success', 'Авторизован'),
+  'password': ('info', 'Ожидается пароль 2FA'),
+  'code': ('warning', 'Ожидается код из Telegram'),
+  'none': ('secondary', 'Не авторизован')
+} %}
+{% set badge = stage_badges.get(stage, stage_badges['none']) %}
+
+<div class="settings-hero mb-4 d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+  <div>
+    <h1 class="h3 fw-bold mb-2">Центр управления трекером</h1>
+    <p class="mb-0 text-white-50">Настройте подключение к Telegram, период проверки и параметры доступа из одной точки.</p>
+  </div>
+  <div class="text-lg-end">
+    <span class="badge bg-{{ badge[0] }} rounded-pill px-3 py-2">
+      <i class="bi bi-shield-lock me-2"></i>{{ badge[1] }}
+    </span>
+    {% if last_code_sent %}
+      <div class="small text-white-50 mt-2"><i class="bi bi-clock-history me-1"></i>Последний код: {{ last_code_sent }}</div>
+    {% endif %}
+  </div>
+</div>
+
+<ul class="stage-flow mb-4">
+  {% set stages = stage_flow or ['none', 'code', 'password', 'authorized'] %}
+  {% set titles = {
+    'none': ('Старт', 'Укажите API и номер телефона.'),
+    'code': ('Код подтверждения', 'Получите код в Telegram и введите его ниже.'),
+    'password': ('Двухфакторный пароль', 'Введите пароль, если включена 2FA.'),
+    'authorized': ('Готово', 'Сервис отслеживает статусы автоматически.')
+  } %}
+  {% for item in stages %}
+    {% set idx = loop.index %}
+    {% set item_index = loop.index0 %}
+    {% set classes = '' %}
+    {% if item_index < stage_index %}
+      {% set classes = 'active' %}
+    {% elif item_index == stage_index %}
+      {% set classes = 'active current' %}
+    {% elif stage == 'code' and item == 'password' %}
+      {% set classes = 'waiting' %}
+    {% elif stage == 'password' and item == 'authorized' %}
+      {% set classes = 'waiting' %}
+    {% endif %}
+    <li class="{{ classes }}">
+      <div class="stage-index">{{ idx }}</div>
+      <div class="fw-semibold">{{ titles[item][0] }}</div>
+      <div class="text-white-50 small">{{ titles[item][1] }}</div>
+    </li>
+  {% endfor %}
+</ul>
 
 <div class="row g-4">
-  <div class="col-12 col-lg-7">
-    <div class="card bg-dark bg-opacity-25 border-0 shadow-sm h-100">
+  <div class="col-12 col-xl-7">
+    <div class="card settings-card h-100 shadow-sm">
       <div class="card-body">
-        <h5 class="card-title mb-3"><i class="bi bi-sliders me-2"></i>Основные параметры</h5>
-        <form method="post">
+        <div class="d-flex align-items-start justify-content-between flex-wrap gap-2 mb-3">
+          <div>
+            <h2 class="h5 fw-semibold mb-1"><i class="bi bi-sliders me-2"></i>Основные параметры</h2>
+            <p class="text-white-50 mb-0">Данные сохраняются мгновенно в базе. Секреты скрыты под звёздочками.</p>
+          </div>
+          <span class="badge bg-light text-dark">{{ keys|length }} полей</span>
+        </div>
+        <form method="post" class="d-flex flex-column h-100">
           <input type="hidden" name="form" value="cfg">
-          <div class="table-responsive">
+          <div class="table-responsive flex-grow-1">
             <table class="table table-dark-glass align-middle mb-0">
               <thead>
                 <tr>
-                  <th>Ключ</th>
+                  <th style="width: 30%">Ключ</th>
                   <th>Значение</th>
                 </tr>
               </thead>
@@ -24,7 +146,7 @@
                     <td class="text-white-50"><code>{{ k }}</code></td>
                     <td>
                       {% set type = 'password' if ('PASS' in k or 'HASH' in k or 'SECRET' in k) else 'text' %}
-                      <input class="form-control" type="{{ type }}" name="{{ k }}" value="{{ cfg.get(k,'') }}">
+                      <input class="form-control" type="{{ type }}" name="{{ k }}" value="{{ cfg.get(k,'') }}" autocomplete="off">
                     </td>
                   </tr>
                 {% endfor %}
@@ -32,69 +154,118 @@
             </table>
           </div>
           <div class="text-end mt-3">
-            <button class="btn btn-success" type="submit"><i class="bi bi-save"></i> Сохранить</button>
+            <button class="btn btn-success px-4" type="submit"><i class="bi bi-save me-2"></i>Сохранить изменения</button>
           </div>
         </form>
       </div>
     </div>
   </div>
-  <div class="col-12 col-lg-5 d-flex flex-column gap-4">
-    <div class="card bg-dark bg-opacity-25 border-0 shadow-sm">
+  <div class="col-12 col-xl-5 d-flex flex-column gap-4">
+    <div class="card settings-card shadow-sm">
       <div class="card-body">
-        <h5 class="card-title mb-3"><i class="bi bi-globe me-2"></i>Часовой пояс отображения</h5>
-        <form method="post" action="{{ url_for('update_timezone') }}" class="d-grid gap-3">
-          <div>
-            <label class="form-label text-white-50">Выберите таймзону</label>
+        <h2 class="h5 fw-semibold mb-3"><i class="bi bi-globe me-2"></i>Часовой пояс</h2>
+        <p class="text-white-50 small mb-3">Выберите локальный часовой пояс для корректного отображения меток времени в отчётах и графиках.</p>
+        <form method="post" action="{{ url_for('update_timezone') }}" class="row g-3 align-items-end">
+          <div class="col-12">
+            <label class="form-label">Отображать время как</label>
             <select name="timezone" class="form-select" data-current="{{ timezone_name }}">
               {% for tz in timezones %}
                 <option value="{{ tz }}" {% if tz == timezone_name %}selected{% endif %}>{{ tz }}</option>
               {% endfor %}
             </select>
           </div>
-          <button class="btn btn-outline-light" type="submit"><i class="bi bi-clock"></i> Обновить</button>
+          <div class="col-12 text-end">
+            <button class="btn btn-outline-light" type="submit"><i class="bi bi-clock me-2"></i>Применить</button>
+          </div>
         </form>
       </div>
     </div>
 
-    <div class="card bg-dark bg-opacity-25 border-0 shadow-sm">
+    <div class="card settings-card shadow-sm">
       <div class="card-body">
-        <h5 class="card-title mb-3"><i class="bi bi-telegram me-2"></i>Авторизация Telegram</h5>
+        <h2 class="h5 fw-semibold mb-3"><i class="bi bi-telegram me-2"></i>Авторизация Telegram</h2>
         {% if stage == 'authorized' %}
-          <div class="alert alert-success">Статус: Авторизован ✅</div>
-          <form method="post" action="{{ url_for('http_logout') }}">
-            <button class="btn btn-outline-danger w-100" type="submit"><i class="bi bi-box-arrow-right"></i> Разлогиниться</button>
+          <div class="alert alert-success d-flex align-items-center gap-2">
+            <i class="bi bi-check-circle-fill"></i>
+            <div>
+              <div class="fw-semibold">Подключение активно</div>
+              <div class="small text-white-50">Трекинг онлайн-статусов выполняется автоматически.</div>
+            </div>
+          </div>
+          <form method="post" action="{{ url_for('http_logout') }}" class="text-end">
+            <button class="btn btn-outline-danger" type="submit" data-loading-button data-loading-text="Завершаем..."><i class="bi bi-box-arrow-right me-2"></i>Разлогиниться</button>
           </form>
         {% elif stage == 'code' %}
-          <div class="alert alert-warning">Статус: Ожидается код из Telegram</div>
+          <div class="alert alert-warning d-flex gap-2">
+            <i class="bi bi-hourglass-split"></i>
+            <div>
+              <div class="fw-semibold">Ждём подтверждения кода</div>
+              <div class="small text-white-50">Получите код в официальном клиенте Telegram и введите его ниже.</div>
+            </div>
+          </div>
           <form method="post" action="{{ url_for('http_send_code') }}" class="d-grid gap-2 mb-3">
-            <button class="btn btn-outline-light" type="submit"><i class="bi bi-send"></i> Отправить код ещё раз</button>
+            <button class="btn btn-outline-light" type="submit" data-loading-button data-loading-text="Отправляем..."><i class="bi bi-send me-2"></i>Запросить код повторно</button>
           </form>
           <form method="post" action="{{ url_for('http_submit_code') }}" class="row g-2">
-            <div class="col-8">
-              <input class="form-control" name="code" placeholder="Код">
+            <div class="col-12 col-sm-8">
+              <label class="form-label small text-white-50">Код подтверждения</label>
+              <input class="form-control" name="code" placeholder="12345" autocomplete="one-time-code">
             </div>
-            <div class="col-4">
-              <button class="btn btn-primary w-100" type="submit">Подтвердить</button>
+            <div class="col-12 col-sm-4 d-flex align-items-end">
+              <button class="btn btn-primary w-100" type="submit" data-loading-button data-loading-text="Проверяем..."><i class="bi bi-shield-check me-2"></i>Подтвердить</button>
             </div>
           </form>
         {% elif stage == 'password' %}
-          <div class="alert alert-info">Статус: Требуется пароль (2FA)</div>
-          <form method="post" action="{{ url_for('http_submit_password') }}" class="row g-2">
-            <div class="col-8">
-              <input class="form-control" type="password" name="password" placeholder="Пароль">
+          <div class="alert alert-info d-flex gap-2">
+            <i class="bi bi-key"></i>
+            <div>
+              <div class="fw-semibold">Нужен пароль двухфакторной защиты</div>
+              <div class="small text-white-50">Ваша учётная запись защищена 2FA. Введите пароль, чтобы завершить вход.</div>
             </div>
-            <div class="col-4">
-              <button class="btn btn-primary w-100" type="submit">Войти</button>
+          </div>
+          <form method="post" action="{{ url_for('http_submit_password') }}" class="row g-2">
+            <div class="col-12 col-sm-8">
+              <label class="form-label small text-white-50">Пароль</label>
+              <input class="form-control" type="password" name="password" placeholder="••••••" autocomplete="current-password">
+            </div>
+            <div class="col-12 col-sm-4 d-flex align-items-end">
+              <button class="btn btn-primary w-100" type="submit" data-loading-button data-loading-text="Проверяем..."><i class="bi bi-door-open me-2"></i>Войти</button>
             </div>
           </form>
         {% else %}
-          <div class="alert alert-secondary">Статус: Не авторизован</div>
+          <div class="alert alert-secondary d-flex gap-2">
+            <i class="bi bi-info-circle"></i>
+            <div>
+              <div class="fw-semibold">Телеграм ещё не подключён</div>
+              <div class="small text-white-50">Нажмите кнопку ниже, чтобы получить SMS/код в приложении Telegram и начать авторизацию.</div>
+            </div>
+          </div>
           <form method="post" action="{{ url_for('http_send_code') }}" class="d-grid gap-2">
-            <button class="btn btn-primary" type="submit"><i class="bi bi-send"></i> Отправить код</button>
+            <button class="btn btn-primary" type="submit" data-loading-button data-loading-text="Отправляем..."><i class="bi bi-send me-2"></i>Отправить код</button>
           </form>
+        {% endif %}
+        {% if last_code_sent %}
+          <p class="small text-white-50 mt-3 mb-0"><i class="bi bi-chat-left-dots me-1"></i>Последний запрос на код: {{ last_code_sent }}</p>
         {% endif %}
       </div>
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  <script>
+    document.querySelectorAll('[data-loading-button]').forEach((btn) => {
+      const form = btn.closest('form');
+      if (!form) return;
+      form.addEventListener('submit', () => {
+        if (btn.dataset.loadingActive) return;
+        btn.dataset.loadingActive = '1';
+        btn.dataset.originalLabel = btn.innerHTML;
+        btn.disabled = true;
+        const text = btn.dataset.loadingText || 'Подождите...';
+        btn.innerHTML = `<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>${text}`;
+      }, { once: false });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- добавить хранение времени последней отправки и проверку готовности Telegram-клиента перед запросом кода, а также обработку FloodWait
- ограничить слишком частые запросы из веб-интерфейса и отображать последнее время отправки
- переработать страницу настроек: новый геро-блок, визуализация этапов авторизации, обновлённые карточки и кнопки с индикаторами загрузки

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d495a638a4832290fa0a2aaccdf7f3